### PR TITLE
Fixes production JIT build by properly disabling build optimizer.…

### DIFF
--- a/config/build-utils.js
+++ b/config/build-utils.js
@@ -75,7 +75,7 @@ function ngcWebpackSetup(prod, metadata) {
     metadata = DEFAULT_METADATA;
   }
 
-  const buildOptimizer = prod;
+  const buildOptimizer = prod && metadata.AOT;
   const sourceMap = true; // TODO: apply based on tsconfig value?
   const ngcWebpackPluginOptions = {
     skipCodeGeneration: !metadata.AOT,
@@ -106,7 +106,7 @@ function ngcWebpackSetup(prod, metadata) {
   const loaders = [
     {
       test: /(?:\.ngfactory\.js|\.ngstyle\.js|\.ts)$/,
-      use: metadata.AOT && buildOptimizer ? [ buildOptimizerLoader, '@ngtools/webpack' ] : [ '@ngtools/webpack' ]
+      use: buildOptimizer ? [ buildOptimizerLoader, '@ngtools/webpack' ] : [ '@ngtools/webpack' ]
     },
     ...buildOptimizer
       ? [ { test: /\.js$/, use: [ buildOptimizerLoader ] } ]


### PR DESCRIPTION
… Build optimizer only works for AOT builds. 

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix
See line 112 of config/build-utils.js - previously it wasn't checking for AOT flag.

* **What is the current behavior?** (You can also link to an open issue here)
Build optimizer loader is used for the non-AOT builds. #1947 #1921 #1940 


* **What is the new behavior (if this is a feature change)?**
Build optimizer loader is properly disabled for the non-AOT builds. 


* **Other information**:

  
  
  