### PR TITLE
fix: Bumped openssl version in docker to make image buildable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ FROM nginx:1.13.0-alpine
 
 # install console and node
 RUN apk add --no-cache bash=4.3.46-r5 &&\
-    apk add --no-cache openssl=1.0.2m-r0 &&\
+    apk add --no-cache openssl=1.0.2n-r0 &&\
     apk add --no-cache nodejs
 
 # install npm ( in separate dir due to docker cache)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Docker image does not build


* **What is the new behavior (if this is a feature change)?**
Docker image builds


* **Other information**:
Seems like the base docker image have moved forward and the specific version of openssl requested couldn't be installed cleanly on top of it.