### PR TITLE
Added webdriver-manager update call into .travis.yml in order to fix …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,11 @@ before_install:
   - npm prune
   - npm update
 
-before_script:
-  - node ./node_modules/protractor/bin/webdriver-manager update
-
 install:
   - npm install
+
+before_script:
+  - node ./node_modules/protractor/bin/webdriver-manager update
 
 script:
   - npm run ci:travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ before_install:
   - npm prune
   - npm update
 
+before_script:
+  - node ./node_modules/protractor/bin/webdriver-manager update
+
 install:
   - npm install
 


### PR DESCRIPTION
…CI builds

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Travis CI build fails:

`Error message: Could not find update-config.json. Run 'webdriver-manager update' to download binaries.
[15:36:38] E/direct - Error: Could not find update-config.json. Run 'webdriver-manager update' to download binaries.`

* **What is the new behavior (if this is a feature change)?**

explicitly calling webdriver-manager update on Before Script stage of the Travis CI build

* **Other information**:
