### PR TITLE
Attempt to fix sometimes failing Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,11 @@ before_install:
   - npm prune
   - npm update
 
-before_script:
-  - node ./node_modules/protractor/bin/webdriver-manager update
-
 install:
   - npm install
+
+before_script:
+  - node ./node_modules/protractor/bin/webdriver-manager update
 
 script:
   - npm run ci:travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ before_install:
   - npm prune
   - npm update
 
+before_script:
+  - node ./node_modules/protractor/bin/webdriver-manager update
+
 install:
   - npm install
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Travis CI build fails occasionally with the following message:

[23:07:14] E/direct - Error message: Could not find update-config.json. Run 'webdriver-manager update' to download binaries.
[23:07:14] E/direct - Error: Could not find update-config.json. Run 'webdriver-manager update' to download binaries.

Even though the same webdriver-update is getting called during the npm install stage:

> node ./node_modules/protractor/bin/webdriver-manager update
[23:03:56] I/file_manager - creating folder /home/travis/build/gdi2290/angular-starter/node_modules/protractor/node_modules/webdriver-manager/selenium
(node:5069) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: Failed to make Github request, rate limit reached.
[23:03:57] I/update - chromedriver: unzipping chromedriver_2.35.zip
[23:03:57] I/update - chromedriver: setting permissions to 0755 for /home/travis/build/gdi2290/angular-starter/node_modules/protractor/node_modules/webdriver-manager/selenium/chromedriver_2.35

* **What is the new behavior (if this is a feature change)?**

Put back call to webdriver-update into the before_script stage of Travis CI build.

* **Other information**:
